### PR TITLE
For testing purposes: AWS Secrets Manager without creating secret

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -22,11 +22,6 @@ resource "aws_route53_record" "app_server" {
 # AWS Secrets Management
 #-------------------------------------------------------------------------------
 
-resource "aws_secretsmanager_secret" "oauth2_tokens" {
-  name                    = "email_oauth2_proxy_tokens"
-  recovery_window_in_days = 0
-}
-
 resource "aws_iam_user" "user_email_oauth2_proxy" {
   name = "email_oauth2_proxy"
 }

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -43,7 +43,7 @@ resource "aws_iam_user_policy" "oauth2_tokens_readwrite" {
           "secretsmanager:GetSecretValue",
           "secretsmanager:PutSecretValue",
         ]
-        Resource = aws_secretsmanager_secret.oauth2_tokens.arn
+        Resource = "*"
       },
     ]
   })
@@ -139,7 +139,7 @@ resource "aws_instance" "app_server" {
       email_oauth2_proxy_repo     = var.email_oauth2_proxy_repo
       email_oauth2_proxy_version  = var.email_oauth2_proxy_version
       email_oauth2_proxy_config   = var.email_oauth2_proxy_config
-      email_oauth2_aws_secret_arn = aws_secretsmanager_secret.oauth2_tokens.arn
+      email_oauth2_aws_secret_arn = ""
       cert_fullchain              = "${acme_certificate.certificate.certificate_pem}${acme_certificate.certificate.issuer_pem}"
       cert_privkey                = acme_certificate.certificate.private_key_pem
       ssh_host_ed25519_privkey    = tls_private_key.ssh_host_ed25519_key.private_key_openssh

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -42,6 +42,7 @@ resource "aws_iam_user_policy" "oauth2_tokens_readwrite" {
         Action = [
           "secretsmanager:GetSecretValue",
           "secretsmanager:PutSecretValue",
+          "secretsmanager:CreateSecret",
         ]
         Resource = "*"
       },


### PR DESCRIPTION
This PR was created for testing purposes and will be closed without merging.

This Terraform config was used to verify that the proxy will seamlessly create the specified AWS Secret if it does not yet exist. The config:
- does not create the AWS Secret
- grants additional permissions so that the IAM user can create the secret